### PR TITLE
feat: add attendance streak feature with badges and detail sheet

### DIFF
--- a/college-ios-app/college-ios-app/App/CollegeIOSApp.swift
+++ b/college-ios-app/college-ios-app/App/CollegeIOSApp.swift
@@ -78,6 +78,27 @@ struct CollegeIOSApp: App {
         return PerformanceViewModel(api: performanceAPI)
     }()
 
+    @StateObject private var streakViewModel: StreakViewModel = {
+        let refreshStorage = KeychainTokenStorage()
+        let authSession = AuthSession(refreshStorage: refreshStorage)
+
+        let decoder = JSONDecoder()
+
+        let client = AFHTTPClient(baseURL: AppEnvironment.authBaseURL, decoder: decoder)
+        let api = AuthAPI(client: client)
+        let authService = AuthService(api: api, session: authSession)
+
+        let interceptor = AuthRequestInterceptor(authService: authService)
+        let authenticatedClient = AFHTTPClient(
+            baseURL: AppEnvironment.scheduleBaseURL,
+            decoder: decoder,
+            interceptor: interceptor
+        )
+
+        let streakAPI = StreakAPI(client: authenticatedClient)
+        return StreakViewModel(api: streakAPI)
+    }()
+
     @AppStorage("selectedTheme") private var selectedTheme: AppTheme = .system
 
     var body: some Scene {
@@ -86,10 +107,12 @@ struct CollegeIOSApp: App {
                 sessionViewModel: sessionViewModel,
                 scheduleViewModel: scheduleViewModel,
                 attendanceViewModel: attendanceViewModel,
-                performanceViewModel: performanceViewModel
+                performanceViewModel: performanceViewModel,
+                streakViewModel: streakViewModel
             )
             .preferredColorScheme(selectedTheme.colorScheme)
             .environmentObject(sessionViewModel)
+            .environmentObject(streakViewModel)
             .task {
                 sessionViewModel.bootstrapAutoLogin()
             }

--- a/college-ios-app/college-ios-app/App/CollegeIOSApp.swift
+++ b/college-ios-app/college-ios-app/App/CollegeIOSApp.swift
@@ -7,10 +7,29 @@
 
 import SwiftUI
 
+// MARK: - Shared Dependencies
+
+private enum SharedDependencies {
+    static let refreshStorage = KeychainTokenStorage()
+    static let authSession = AuthSession(refreshStorage: refreshStorage)
+    static let decoder = JSONDecoder()
+
+    static let authClient = AFHTTPClient(baseURL: AppEnvironment.authBaseURL, decoder: decoder)
+    static let authAPI = AuthAPI(client: authClient)
+    static let authService = AuthService(api: authAPI, session: authSession)
+
+    static let interceptor = AuthRequestInterceptor(authService: authService)
+    static let authenticatedClient = AFHTTPClient(
+        baseURL: AppEnvironment.scheduleBaseURL,
+        decoder: decoder,
+        interceptor: interceptor
+    )
+}
+
 @main
 struct CollegeIOSApp: App {
     @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
-    
+
     @StateObject private var scheduleViewModel: ScheduleViewModel = {
         let client = AFHTTPClient(baseURL: AppEnvironment.scheduleBaseURL)
         let api = ScheduleAPI(client: client)
@@ -24,78 +43,24 @@ struct CollegeIOSApp: App {
     }()
 
     @StateObject private var sessionViewModel: SessionViewModel = {
-        let refreshStorage = KeychainTokenStorage()
-        let authSession = AuthSession(refreshStorage: refreshStorage)
-
-        let decoder = JSONDecoder()
-
-        let client = AFHTTPClient(baseURL: AppEnvironment.authBaseURL, decoder: decoder)
-        let api = AuthAPI(client: client)
-        let authService = AuthService(api: api, session: authSession)
-
-        return SessionViewModel(authService: authService, authSession: authSession)
+        SessionViewModel(
+            authService: SharedDependencies.authService,
+            authSession: SharedDependencies.authSession
+        )
     }()
 
     @StateObject private var attendanceViewModel: AttendanceViewModel = {
-        let refreshStorage = KeychainTokenStorage()
-        let authSession = AuthSession(refreshStorage: refreshStorage)
-
-        let decoder = JSONDecoder()
-
-        let client = AFHTTPClient(baseURL: AppEnvironment.authBaseURL, decoder: decoder)
-        let api = AuthAPI(client: client)
-        let authService = AuthService(api: api, session: authSession)
-
-        let interceptor = AuthRequestInterceptor(authService: authService)
-        let authenticatedClient = AFHTTPClient(
-            baseURL: AppEnvironment.scheduleBaseURL,
-            decoder: decoder,
-            interceptor: interceptor
-        )
-
-        let attendanceAPI = AttendanceAPI(client: authenticatedClient)
+        let attendanceAPI = AttendanceAPI(client: SharedDependencies.authenticatedClient)
         return AttendanceViewModel(api: attendanceAPI)
     }()
 
     @StateObject private var performanceViewModel: PerformanceViewModel = {
-        let refreshStorage = KeychainTokenStorage()
-        let authSession = AuthSession(refreshStorage: refreshStorage)
-
-        let decoder = JSONDecoder()
-
-        let client = AFHTTPClient(baseURL: AppEnvironment.authBaseURL, decoder: decoder)
-        let api = AuthAPI(client: client)
-        let authService = AuthService(api: api, session: authSession)
-
-        let interceptor = AuthRequestInterceptor(authService: authService)
-        let authenticatedClient = AFHTTPClient(
-            baseURL: AppEnvironment.scheduleBaseURL,
-            decoder: decoder,
-            interceptor: interceptor
-        )
-
-        let performanceAPI = PerformanceAPI(client: authenticatedClient)
+        let performanceAPI = PerformanceAPI(client: SharedDependencies.authenticatedClient)
         return PerformanceViewModel(api: performanceAPI)
     }()
 
     @StateObject private var streakViewModel: StreakViewModel = {
-        let refreshStorage = KeychainTokenStorage()
-        let authSession = AuthSession(refreshStorage: refreshStorage)
-
-        let decoder = JSONDecoder()
-
-        let client = AFHTTPClient(baseURL: AppEnvironment.authBaseURL, decoder: decoder)
-        let api = AuthAPI(client: client)
-        let authService = AuthService(api: api, session: authSession)
-
-        let interceptor = AuthRequestInterceptor(authService: authService)
-        let authenticatedClient = AFHTTPClient(
-            baseURL: AppEnvironment.scheduleBaseURL,
-            decoder: decoder,
-            interceptor: interceptor
-        )
-
-        let streakAPI = StreakAPI(client: authenticatedClient)
+        let streakAPI = StreakAPI(client: SharedDependencies.authenticatedClient)
         return StreakViewModel(api: streakAPI)
     }()
 

--- a/college-ios-app/college-ios-app/App/RootView.swift
+++ b/college-ios-app/college-ios-app/App/RootView.swift
@@ -12,7 +12,8 @@ struct RootView: View {
     @ObservedObject var scheduleViewModel: ScheduleViewModel
     @ObservedObject var attendanceViewModel: AttendanceViewModel
     @ObservedObject var performanceViewModel: PerformanceViewModel
-
+    @ObservedObject var streakViewModel: StreakViewModel
+    
     var body: some View {
         Group {
             if sessionViewModel.isBootstrapping {
@@ -27,5 +28,19 @@ struct RootView: View {
             }
         }
         .animation(.easeInOut(duration: 0.3), value: sessionViewModel.isBootstrapping)
+        .onChange(of: sessionViewModel.isAuthenticated) { _, isAuthenticated in
+            if isAuthenticated {
+                Task {
+                    await streakViewModel.loadStreak()
+                }
+            } else {
+                streakViewModel.clear()
+            }
+        }
+        .task {
+            if sessionViewModel.isAuthenticated {
+                await streakViewModel.loadStreak()
+            }
+        }
     }
 }

--- a/college-ios-app/college-ios-app/App/RootView.swift
+++ b/college-ios-app/college-ios-app/App/RootView.swift
@@ -35,6 +35,8 @@ struct RootView: View {
                 }
             } else {
                 streakViewModel.clear()
+                attendanceViewModel.clear()
+                performanceViewModel.clear()
             }
         }
         .task {

--- a/college-ios-app/college-ios-app/Features/Attendance/ViewModels/AttendanceViewModel.swift
+++ b/college-ios-app/college-ios-app/Features/Attendance/ViewModels/AttendanceViewModel.swift
@@ -162,10 +162,17 @@ final class AttendanceViewModel: ObservableObject {
     func refresh() async {
         await loadCurrentWeekAttendance()
     }
-    
+
     func loadSelectedWeek() async {
         isLoadingWeek = true
         await loadAttendance(start: selectedWeekRange.start, end: selectedWeekRange.end, showFullScreenLoader: false)
         isLoadingWeek = false
+    }
+
+    func clear() {
+        records = []
+        errorMessage = nil
+        didInitialLoad = false
+        selectedWeekRange = Self.calculateCurrentWeekRange()
     }
 }

--- a/college-ios-app/college-ios-app/Features/Attendance/Views/AttendanceHeaderControls.swift
+++ b/college-ios-app/college-ios-app/Features/Attendance/Views/AttendanceHeaderControls.swift
@@ -29,28 +29,35 @@ struct AttendanceHeaderControls: View {
     // MARK: - Quick Navigation Buttons
     
     private var quickNavigationButtons: some View {
-        ScrollView(.horizontal, showsIndicators: false) {
-            HStack(spacing: 10) {
+        VStack(spacing: 8) {
+            HStack {
                 quickWeekButton(title: "Текущая неделя", weeksOffset: 0)
-                quickWeekButton(title: "Прошлая неделя", weeksOffset: -1)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 2)
                 
-                Button {
-                    customStartDate = viewModel.selectedWeekRange.start
-                    customEndDate = viewModel.selectedWeekRange.end
-                    showDatePicker = true
-                } label: {
-                    Label("Выбрать", systemImage: "calendar")
-                        .font(.subheadline.weight(.medium))
-                        .padding(.horizontal, 16)
-                        .padding(.vertical, 8)
-                        .background(Color.blue.opacity(0.1))
-                        .foregroundColor(.blue)
-                        .cornerRadius(20)
-                }
+                quickWeekButton(title: "Прошлая неделя", weeksOffset: -1)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 2)
             }
-            .padding(.horizontal)
+            
+            Button {
+                customStartDate = viewModel.selectedWeekRange.start
+                customEndDate = viewModel.selectedWeekRange.end
+                showDatePicker = true
+            } label: {
+                Label("Выбрать", systemImage: "calendar")
+                    .font(.subheadline.weight(.medium))
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 10)
+                    .background(Color.blue.opacity(0.1))
+                    .foregroundColor(.blue)
+                    .cornerRadius(12)
+            }
         }
+        .padding(.horizontal)
+        .frame(maxWidth: .infinity)
     }
+    
     
     @ViewBuilder
     private func quickWeekButton(title: String, weeksOffset: Int) -> some View {
@@ -76,14 +83,14 @@ struct AttendanceHeaderControls: View {
         } label: {
             Text(title)
                 .font(.subheadline.weight(.medium))
-                .padding(.horizontal, 16)
-                .padding(.vertical, 8)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 10)
                 .background(
                     isSelectedWeek(weeksOffset)
                     ? Color.blue : Color(.tertiarySystemGroupedBackground)
                 )
                 .foregroundColor(isSelectedWeek(weeksOffset) ? .white : .primary)
-                .cornerRadius(20)
+                .cornerRadius(12)
         }
     }
     

--- a/college-ios-app/college-ios-app/Features/Attendance/Views/AttendanceHeaderControls.swift
+++ b/college-ios-app/college-ios-app/Features/Attendance/Views/AttendanceHeaderControls.swift
@@ -84,7 +84,7 @@ struct AttendanceHeaderControls: View {
             Text(title)
                 .font(.subheadline.weight(.medium))
                 .frame(maxWidth: .infinity)
-                .padding(.vertical, 10)
+                .padding(.vertical, 12)
                 .background(
                     isSelectedWeek(weeksOffset)
                     ? Color.blue : Color(.tertiarySystemGroupedBackground)

--- a/college-ios-app/college-ios-app/Features/Attendance/Views/AttendanceView.swift
+++ b/college-ios-app/college-ios-app/Features/Attendance/Views/AttendanceView.swift
@@ -71,9 +71,6 @@ struct AttendanceView: View {
                 .padding()
             }
         }
-        .refreshable {
-            await viewModel.refresh()
-        }
     }
     
     private var weekLoadingView: some View {

--- a/college-ios-app/college-ios-app/Features/Attendance/Views/AttendanceView.swift
+++ b/college-ios-app/college-ios-app/Features/Attendance/Views/AttendanceView.swift
@@ -24,6 +24,7 @@ struct AttendanceView: View {
         .background(Color(.systemGroupedBackground))
         .navigationTitle("Посещаемость")
         .navigationBarTitleDisplayMode(.large)
+        .streakToolbar()
         .accountToolbar()
         .toolbar {
             ToolbarItem(placement: .navigationBarLeading) {
@@ -43,16 +44,12 @@ struct AttendanceView: View {
         .task {
             viewModel.onAppearOnce()
         }
-        .refreshable {
-            await viewModel.refresh()
-        }
     }
     
     private var attendanceContent: some View {
-        VStack(spacing: 0) {
-            AttendanceHeaderControls(viewModel: viewModel)
-            
-            ScrollView {
+        ScrollView {
+            VStack(spacing: 0) {
+                AttendanceHeaderControls(viewModel: viewModel)
                 VStack(spacing: 16) {
                     AttendanceStatisticsCard(viewModel: viewModel)
                     
@@ -73,6 +70,9 @@ struct AttendanceView: View {
                 }
                 .padding()
             }
+        }
+        .refreshable {
+            await viewModel.refresh()
         }
     }
     

--- a/college-ios-app/college-ios-app/Features/Performance/ViewModels/PerformanceViewModel.swift
+++ b/college-ios-app/college-ios-app/Features/Performance/ViewModels/PerformanceViewModel.swift
@@ -53,9 +53,15 @@ final class PerformanceViewModel: ObservableObject {
     func refresh() async {
         await loadSubjects()
     }
-    
+
+    func clear() {
+        subjects = []
+        errorMessage = nil
+        didInitialLoad = false
+    }
+
     // MARK: - Factory
-    
+
     func makeSubjectDetailViewModel(for subject: PerformanceSubject) -> SubjectDetailViewModel {
         SubjectDetailViewModel(api: api, subject: subject)
     }

--- a/college-ios-app/college-ios-app/Features/Performance/Views/PerformanceView.swift
+++ b/college-ios-app/college-ios-app/Features/Performance/Views/PerformanceView.swift
@@ -25,6 +25,7 @@ struct PerformanceView: View {
             .background(Color(.systemGroupedBackground))
             .navigationTitle("Успеваемость")
             .navigationBarTitleDisplayMode(.large)
+            .streakToolbar()
             .accountToolbar()
             .task {
                 viewModel.onAppearOnce()

--- a/college-ios-app/college-ios-app/Features/Performance/Views/SubjectDetailView.swift
+++ b/college-ios-app/college-ios-app/Features/Performance/Views/SubjectDetailView.swift
@@ -11,13 +11,15 @@ struct SubjectDetailView: View {
     @ObservedObject var viewModel: SubjectDetailViewModel
     
     var body: some View {
-        VStack(spacing: 0) {
-            if viewModel.isLoading && viewModel.lessons.isEmpty {
-                loadingView
-            } else if let error = viewModel.errorMessage, viewModel.lessons.isEmpty {
-                errorView(message: error)
-            } else {
-                detailContent
+        ScrollView {
+            VStack(spacing: 0) {
+                if viewModel.isLoading && viewModel.lessons.isEmpty {
+                    loadingView
+                } else if let error = viewModel.errorMessage, viewModel.lessons.isEmpty {
+                    errorView(message: error)
+                } else {
+                    detailContent
+                }
             }
         }
         .toolbar {
@@ -33,47 +35,42 @@ struct SubjectDetailView: View {
     }
     
     private var detailContent: some View {
-        ScrollView {
-            VStack(spacing: 16) {
-                StatisticsCard(statistics: viewModel.statistics)
-                
-                if !viewModel.lessonsWithGradedScores.isEmpty {
-                    VStack(alignment: .leading, spacing: 12) {
-                        Text("Выставленные оценки")
-                            .font(.headline)
-                            .padding(.horizontal)
-                        
-                        LazyVStack(spacing: 12) {
-                            ForEach(viewModel.lessonsWithGradedScores) { lesson in
-                                LessonScoreCard(lesson: lesson, showOnlyGraded: true)
-                            }
+        VStack(spacing: 16) {
+            StatisticsCard(statistics: viewModel.statistics)
+
+            if !viewModel.lessonsWithGradedScores.isEmpty {
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("Выставленные оценки")
+                        .font(.headline)
+                        .padding(.horizontal)
+
+                    LazyVStack(spacing: 12) {
+                        ForEach(viewModel.lessonsWithGradedScores) { lesson in
+                            LessonScoreCard(lesson: lesson, showOnlyGraded: true)
                         }
                     }
-                }
-                
-                if !viewModel.lessonsWithPendingScores.isEmpty {
-                    VStack(alignment: .leading, spacing: 12) {
-                        Text("Ожидают оценки")
-                            .font(.headline)
-                            .padding(.horizontal)
-                        
-                        LazyVStack(spacing: 12) {
-                            ForEach(viewModel.lessonsWithPendingScores) { lesson in
-                                LessonScoreCard(lesson: lesson, showOnlyGraded: false)
-                            }
-                        }
-                    }
-                }
-                
-                if viewModel.lessons.isEmpty {
-                    emptyMessage
                 }
             }
-            .padding()
+
+            if !viewModel.lessonsWithPendingScores.isEmpty {
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("Ожидают оценки")
+                        .font(.headline)
+                        .padding(.horizontal)
+
+                    LazyVStack(spacing: 12) {
+                        ForEach(viewModel.lessonsWithPendingScores) { lesson in
+                            LessonScoreCard(lesson: lesson, showOnlyGraded: false)
+                        }
+                    }
+                }
+            }
+
+            if viewModel.lessons.isEmpty {
+                emptyMessage
+            }
         }
-        .refreshable {
-            await viewModel.refresh()
-        }
+        .padding()
     }
     
     private var loadingView: some View {

--- a/college-ios-app/college-ios-app/Features/Schedule/Views/ScheduleView.swift
+++ b/college-ios-app/college-ios-app/Features/Schedule/Views/ScheduleView.swift
@@ -35,6 +35,7 @@ struct ScheduleView: View {
         .background(Color(.systemGroupedBackground))
         .navigationTitle("Расписание")
         .navigationBarTitleDisplayMode(.large)
+        .streakToolbar()
         .accountToolbar()
         .task {
             viewModel.onAppearOnce()

--- a/college-ios-app/college-ios-app/Features/Settings/Views/DeveloperSettingsView.swift
+++ b/college-ios-app/college-ios-app/Features/Settings/Views/DeveloperSettingsView.swift
@@ -17,6 +17,7 @@ struct DeveloperSettingsView: View {
     var body: some View {
         List {
             infoSection
+            streakDebugSection
             actionsSection
         }
         .navigationTitle("Developer")
@@ -54,6 +55,38 @@ struct DeveloperSettingsView: View {
             InfoRow(title: "Bundle ID", value: deviceInfo.bundleId)
         } header: {
             Text("Информация")
+        }
+    }
+    
+    // MARK: - Streak Debug Section
+    
+    private var streakDebugSection: some View {
+        Section {
+            let storage = StreakStorage()
+            let lastKnown = storage.lastKnownStreak
+            
+            HStack {
+                Text("lastKnownStreak")
+                Spacer()
+                Text(lastKnown.map { "\($0)" } ?? "nil")
+                    .foregroundStyle(.secondary)
+            }
+            
+            Button {
+                resetStreakStorage()
+            } label: {
+                Label {
+                    Text("Сбросить streak")
+                        .foregroundStyle(.orange)
+                } icon: {
+                    Image(systemName: "flame.fill")
+                        .foregroundStyle(.orange)
+                }
+            }
+        } header: {
+            Text("Streak Debug")
+        } footer: {
+            Text("После сброса при следующем запуске увидите анимацию +N с полным значением streak")
         }
     }
     
@@ -130,6 +163,16 @@ struct DeveloperSettingsView: View {
     
     private func reloadWidgets() {
         WidgetCenter.shared.reloadAllTimelines()
+        
+        showClearedToast = true
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+            showClearedToast = false
+        }
+    }
+    
+    private func resetStreakStorage() {
+        let storage = StreakStorage()
+        storage.lastKnownStreak = nil
         
         showClearedToast = true
         DispatchQueue.main.asyncAfter(deadline: .now() + 2) {

--- a/college-ios-app/college-ios-app/Features/Settings/Views/SettingsView.swift
+++ b/college-ios-app/college-ios-app/Features/Settings/Views/SettingsView.swift
@@ -54,6 +54,7 @@ struct SettingsView: View {
         }
         .navigationTitle("Настройки")
         .navigationBarTitleDisplayMode(.large)
+        .streakToolbar()
         .accountToolbar()
         .toolbar {
             ToolbarItem(placement: .navigationBarLeading) {

--- a/college-ios-app/college-ios-app/Features/Streak/Data/StreakAPI.swift
+++ b/college-ios-app/college-ios-app/Features/Streak/Data/StreakAPI.swift
@@ -1,0 +1,29 @@
+//
+//  StreakAPI.swift
+//  college-ios-app
+//
+//  Created by pc on 24.11.2025.
+//
+
+import Foundation
+
+protocol StreakAPIProtocol {
+    func fetchStreak() async throws -> StreakResponse
+}
+
+final class StreakAPI: StreakAPIProtocol {
+    private let client: HTTPClientProtocol
+    
+    init(client: HTTPClientProtocol) {
+        self.client = client
+    }
+    
+    func fetchStreak() async throws -> StreakResponse {
+        let endpoint = Endpoint(
+            path: "/api/v1/attendance/streak",
+            method: .get
+        )
+        
+        return try await client.send(endpoint, as: StreakResponse.self)
+    }
+}

--- a/college-ios-app/college-ios-app/Features/Streak/Data/StreakStorage.swift
+++ b/college-ios-app/college-ios-app/Features/Streak/Data/StreakStorage.swift
@@ -1,0 +1,33 @@
+//
+//  StreakStorage.swift
+//  college-ios-app
+//
+//  Created by pc on 26.11.2025.
+//
+
+import Foundation
+
+final class StreakStorage: Sendable {
+    private let defaults: UserDefaults
+    private let lastKnownStreakKey = "streak.lastKnownStreak"
+    
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+    
+    var lastKnownStreak: Int? {
+        get { defaults.object(forKey: lastKnownStreakKey) as? Int }
+        set { defaults.set(newValue, forKey: lastKnownStreakKey) }
+    }
+    
+    func calculateIncrease(newStreak: Int) -> Int {
+        guard let last = lastKnownStreak else {
+            return newStreak
+        }
+        return max(0, newStreak - last)
+    }
+    
+    func updateLastKnown(_ streak: Int) {
+        lastKnownStreak = streak
+    }
+}

--- a/college-ios-app/college-ios-app/Features/Streak/Data/StreakStorage.swift
+++ b/college-ios-app/college-ios-app/Features/Streak/Data/StreakStorage.swift
@@ -30,4 +30,8 @@ final class StreakStorage: Sendable {
     func updateLastKnown(_ streak: Int) {
         lastKnownStreak = streak
     }
+
+    func clear() {
+        lastKnownStreak = nil
+    }
 }

--- a/college-ios-app/college-ios-app/Features/Streak/Models/StreakResponse.swift
+++ b/college-ios-app/college-ios-app/Features/Streak/Models/StreakResponse.swift
@@ -1,0 +1,30 @@
+//
+//  StreakResponse.swift
+//  college-ios-app
+//
+//  Created by pc on 24.11.2025.
+//
+
+import Foundation
+
+struct StreakResponse: Decodable, Sendable {
+    let currentStreak: Int
+    let longestStreak: Int
+    let totalDaysAttended: Int
+    let totalSchoolDays: Int
+    let attendanceRate: Double
+    let lastAttendedDate: String?
+    let periodStart: String
+    let periodEnd: String
+    
+    enum CodingKeys: String, CodingKey {
+        case currentStreak = "current_streak"
+        case longestStreak = "longest_streak"
+        case totalDaysAttended = "total_days_attended"
+        case totalSchoolDays = "total_school_days"
+        case attendanceRate = "attendance_rate"
+        case lastAttendedDate = "last_attended_date"
+        case periodStart = "period_start"
+        case periodEnd = "period_end"
+    }
+}

--- a/college-ios-app/college-ios-app/Features/Streak/ViewModels/StreakViewModel.swift
+++ b/college-ios-app/college-ios-app/Features/Streak/ViewModels/StreakViewModel.swift
@@ -52,6 +52,8 @@ final class StreakViewModel: ObservableObject {
     
     func clear() {
         streak = nil
+        streakIncrease = 0
         errorMessage = nil
+        storage.clear()
     }
 }

--- a/college-ios-app/college-ios-app/Features/Streak/ViewModels/StreakViewModel.swift
+++ b/college-ios-app/college-ios-app/Features/Streak/ViewModels/StreakViewModel.swift
@@ -1,0 +1,47 @@
+//
+//  StreakViewModel.swift
+//  college-ios-app
+//
+//  Created by pc on 24.11.2025.
+//
+
+import Foundation
+internal import Combine
+
+@MainActor
+final class StreakViewModel: ObservableObject {
+    @Published private(set) var streak: StreakResponse?
+    @Published private(set) var isLoading: Bool = false
+    @Published var errorMessage: String?
+    
+    private let api: StreakAPIProtocol
+    
+    init(api: StreakAPIProtocol) {
+        self.api = api
+    }
+    
+    func loadStreak() async {
+        isLoading = true
+        errorMessage = nil
+        
+        do {
+            streak = try await api.fetchStreak()
+            isLoading = false
+        } catch let error as APIError {
+            isLoading = false
+            errorMessage = error.errorDescription
+        } catch {
+            isLoading = false
+            errorMessage = "Не удалось загрузить данные о streak"
+        }
+    }
+    
+    func refresh() async {
+        await loadStreak()
+    }
+    
+    func clear() {
+        streak = nil
+        errorMessage = nil
+    }
+}

--- a/college-ios-app/college-ios-app/Features/Streak/ViewModels/StreakViewModel.swift
+++ b/college-ios-app/college-ios-app/Features/Streak/ViewModels/StreakViewModel.swift
@@ -11,13 +11,16 @@ internal import Combine
 @MainActor
 final class StreakViewModel: ObservableObject {
     @Published private(set) var streak: StreakResponse?
+    @Published private(set) var streakIncrease: Int = 0
     @Published private(set) var isLoading: Bool = false
     @Published var errorMessage: String?
     
     private let api: StreakAPIProtocol
+    private let storage: StreakStorage
     
-    init(api: StreakAPIProtocol) {
+    init(api: StreakAPIProtocol, storage: StreakStorage = StreakStorage()) {
         self.api = api
+        self.storage = storage
     }
     
     func loadStreak() async {
@@ -25,7 +28,14 @@ final class StreakViewModel: ObservableObject {
         errorMessage = nil
         
         do {
-            streak = try await api.fetchStreak()
+            let response = try await api.fetchStreak()
+            
+            streakIncrease = storage.calculateIncrease(newStreak: response.currentStreak)
+            
+            streak = response
+            
+            storage.updateLastKnown(response.currentStreak)
+            
             isLoading = false
         } catch let error as APIError {
             isLoading = false

--- a/college-ios-app/college-ios-app/Features/Streak/Views/StreakBadgeView.swift
+++ b/college-ios-app/college-ios-app/Features/Streak/Views/StreakBadgeView.swift
@@ -8,6 +8,7 @@ import SwiftUI
 
 struct StreakBadgeView: View {
     let count: Int
+    var increase: Int = 1
     var isLoading: Bool = false
     
     @State private var displayedCount: Int
@@ -16,8 +17,9 @@ struct StreakBadgeView: View {
     
     private let containerWidth: CGFloat = 75
     
-    init(count: Int, isLoading: Bool = false) {
+    init(count: Int, increase: Int = 1, isLoading: Bool = false) {
         self.count = count
+        self.increase = increase
         self.isLoading = isLoading
         _displayedCount = State(initialValue: count)
     }
@@ -46,8 +48,8 @@ struct StreakBadgeView: View {
                 .offset(x: showPlusOne ? -10 : 0)
                 .scaleEffect(textPopScale)
                 
-                if showPlusOne {
-                    Text("+1")
+                if showPlusOne && increase > 0 {
+                    Text("+\(increase)")
                         .font(.system(size: 14, weight: .bold, design: .rounded))
                         .foregroundColor(.orange)
                         .offset(x: 24)
@@ -64,7 +66,7 @@ struct StreakBadgeView: View {
         .animation(.default, value: displayedCount)
         
         .onChange(of: count) { oldValue, newValue in
-            if newValue > oldValue {
+            if newValue > oldValue && increase > 0 {
                 animateSequence(newValue: newValue)
             } else {
                 displayedCount = newValue
@@ -90,30 +92,117 @@ struct StreakBadgeView: View {
     }
 }
 
-struct StreakCenterPreview: View {
+// MARK: - Static States Preview
+
+#Preview("Все состояния") {
+    VStack(spacing: 24) {
+        Text("Статические состояния")
+            .font(.headline)
+        
+        HStack(spacing: 20) {
+            VStack {
+                StreakBadgeView(count: 0)
+                    .background(Capsule().fill(Color.gray.opacity(0.1)))
+                Text("Пустой")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            
+            VStack {
+                StreakBadgeView(count: 15)
+                    .background(Capsule().fill(Color.gray.opacity(0.1)))
+                Text("Активный")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            
+            VStack {
+                StreakBadgeView(count: 0, isLoading: true)
+                    .background(Capsule().fill(Color.gray.opacity(0.1)))
+                Text("Загрузка")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        
+        Divider()
+        
+        Text("С анимацией прибавки")
+            .font(.headline)
+        
+        HStack(spacing: 20) {
+            VStack {
+                StreakBadgeView(count: 5, increase: 1)
+                    .background(Capsule().fill(Color.gray.opacity(0.1)))
+                Text("+1 день")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            
+            VStack {
+                StreakBadgeView(count: 10, increase: 5)
+                    .background(Capsule().fill(Color.gray.opacity(0.1)))
+                Text("+5 дней")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            
+            VStack {
+                StreakBadgeView(count: 15, increase: 15)
+                    .background(Capsule().fill(Color.gray.opacity(0.1)))
+                Text("Первый запуск")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+    .padding()
+}
+
+// MARK: - Interactive Animation Preview
+
+struct StreakAnimationPreview: View {
     @State private var count = 5
+    @State private var selectedIncrease = 1
+    
+    private let increaseOptions = [1, 3, 5, 10]
     
     var body: some View {
         NavigationStack {
-            VStack {
+            VStack(spacing: 32) {
                 Spacer()
-                Text("Посмотрите на Toolbar сверху")
-                    .foregroundStyle(.secondary)
-                Button("Добавить день") {
-                    count += 1
+                
+                Text("Текущий streak: \(count)")
+                    .font(.title2)
+                
+                Picker("Прибавка", selection: $selectedIncrease) {
+                    ForEach(increaseOptions, id: \.self) { value in
+                        Text("+\(value)").tag(value)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .padding(.horizontal)
+                
+                Button("Добавить \(selectedIncrease) дней") {
+                    count += selectedIncrease
                 }
                 .buttonStyle(.borderedProminent)
-                .padding()
+                
+                Button("Сбросить") {
+                    count = 5
+                }
+                .foregroundStyle(.secondary)
+                
                 Spacer()
             }
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {
-                    StreakBadgeView(count: count)
+                    StreakBadgeView(count: count, increase: selectedIncrease)
                         .background(Capsule().fill(Color.gray.opacity(0.1)))
                 }
                 
                 ToolbarItem(placement: .principal) {
-                    Text("Главная")
+                    Text("Анимация")
                         .bold()
                 }
             }
@@ -121,6 +210,116 @@ struct StreakCenterPreview: View {
     }
 }
 
-#Preview {
-    StreakCenterPreview()
+#Preview("Интерактивная анимация") {
+    StreakAnimationPreview()
+}
+
+// MARK: - First Launch Simulation
+
+struct StreakFirstLaunchPreview: View {
+    @State private var count = 0
+    @State private var hasLoaded = false
+    
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 24) {
+                Spacer()
+                
+                Text("Симуляция первого запуска")
+                    .font(.headline)
+                
+                Text("Студент ходил 15 дней,\nно приложение открыл впервые")
+                    .multilineTextAlignment(.center)
+                    .foregroundStyle(.secondary)
+                
+                Button("Загрузить streak") {
+                    hasLoaded = true
+                    count = 15
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(hasLoaded)
+                
+                Button("Сбросить") {
+                    hasLoaded = false
+                    count = 0
+                }
+                .foregroundStyle(.secondary)
+                
+                Spacer()
+            }
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    StreakBadgeView(
+                        count: count,
+                        increase: hasLoaded ? 15 : 0
+                    )
+                    .background(Capsule().fill(Color.gray.opacity(0.1)))
+                }
+                
+                ToolbarItem(placement: .principal) {
+                    Text("Первый запуск")
+                        .bold()
+                }
+            }
+        }
+    }
+}
+
+#Preview("Первый запуск (+15)") {
+    StreakFirstLaunchPreview()
+}
+
+// MARK: - Week Missed Simulation
+
+struct StreakWeekMissedPreview: View {
+    @State private var count = 10
+    @State private var hasUpdated = false
+    
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 24) {
+                Spacer()
+                
+                Text("Симуляция пропущенной недели")
+                    .font(.headline)
+                
+                Text("Студент не заходил в приложение\nвсю неделю (Пн-Пт), но посещал колледж")
+                    .multilineTextAlignment(.center)
+                    .foregroundStyle(.secondary)
+                
+                Button("Обновить streak (+5 дней)") {
+                    hasUpdated = true
+                    count = 15
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(hasUpdated)
+                
+                Button("Сбросить") {
+                    hasUpdated = false
+                    count = 10
+                }
+                .foregroundStyle(.secondary)
+                
+                Spacer()
+            }
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    StreakBadgeView(
+                        count: count,
+                        increase: hasUpdated ? 5 : 0
+                    )
+                    .background(Capsule().fill(Color.gray.opacity(0.1)))
+                }
+                
+                ToolbarItem(placement: .principal) {
+                    Text("Пн-Пт без приложения")
+                        .bold()
+                }
+            }
+        }
+    }
+}
+
+#Preview("Неделя без приложения (+5)") {
+    StreakWeekMissedPreview()
 }

--- a/college-ios-app/college-ios-app/Features/Streak/Views/StreakBadgeView.swift
+++ b/college-ios-app/college-ios-app/Features/Streak/Views/StreakBadgeView.swift
@@ -1,0 +1,126 @@
+//
+//  StreakBadgeView.swift
+//  college-ios-app
+//  Created by pc on 24.11.2025.
+//
+
+import SwiftUI
+
+struct StreakBadgeView: View {
+    let count: Int
+    var isLoading: Bool = false
+    
+    @State private var displayedCount: Int
+    @State private var showPlusOne: Bool = false
+    @State private var textPopScale: CGFloat = 1.0
+    
+    private let containerWidth: CGFloat = 75
+    
+    init(count: Int, isLoading: Bool = false) {
+        self.count = count
+        self.isLoading = isLoading
+        _displayedCount = State(initialValue: count)
+    }
+    
+    var body: some View {
+        ZStack(alignment: .center) {
+            if isLoading {
+                ProgressView().scaleEffect(0.7)
+            } else {
+                HStack(spacing: 4) {
+                    Image(systemName: "flame.fill")
+                        .font(.system(size: 16))
+                        .foregroundStyle(
+                            LinearGradient(
+                                colors: displayedCount > 0 ? [.orange, .red] : [.gray, .gray.opacity(0.7)],
+                                startPoint: .top,
+                                endPoint: .bottom
+                            )
+                        )
+                    
+                    Text("\(displayedCount)")
+                        .font(.system(size: 16, weight: .bold, design: .rounded))
+                        .foregroundColor(displayedCount > 0 ? .orange : .gray)
+                        .contentTransition(.numericText(value: Double(displayedCount)))
+                }
+                .offset(x: showPlusOne ? -10 : 0)
+                .scaleEffect(textPopScale)
+                
+                if showPlusOne {
+                    Text("+1")
+                        .font(.system(size: 14, weight: .bold, design: .rounded))
+                        .foregroundColor(.orange)
+                        .offset(x: 24)
+                        .transition(.asymmetric(
+                            insertion: .opacity.combined(with: .scale(scale: 0.5)),
+                            removal: .opacity.combined(with: .move(edge: .leading))
+                        ))
+                }
+            }
+        }
+        .frame(width: containerWidth, height: 32)
+        .animation(.spring(response: 0.4, dampingFraction: 0.6), value: showPlusOne)
+        .animation(.spring(response: 0.2, dampingFraction: 0.5), value: textPopScale)
+        .animation(.default, value: displayedCount)
+        
+        .onChange(of: count) { oldValue, newValue in
+            if newValue > oldValue {
+                animateSequence(newValue: newValue)
+            } else {
+                displayedCount = newValue
+            }
+        }
+    }
+    
+    private func animateSequence(newValue: Int) {
+        showPlusOne = true
+        textPopScale = 1.1
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { textPopScale = 1.0 }
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) {
+            showPlusOne = false
+            
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+                displayedCount = newValue
+                textPopScale = 1.2
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { textPopScale = 1.0 }
+            }
+        }
+    }
+}
+
+struct StreakCenterPreview: View {
+    @State private var count = 5
+    
+    var body: some View {
+        NavigationStack {
+            VStack {
+                Spacer()
+                Text("Посмотрите на Toolbar сверху")
+                    .foregroundStyle(.secondary)
+                Button("Добавить день") {
+                    count += 1
+                }
+                .buttonStyle(.borderedProminent)
+                .padding()
+                Spacer()
+            }
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    StreakBadgeView(count: count)
+                        .background(Capsule().fill(Color.gray.opacity(0.1)))
+                }
+                
+                ToolbarItem(placement: .principal) {
+                    Text("Главная")
+                        .bold()
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    StreakCenterPreview()
+}

--- a/college-ios-app/college-ios-app/Features/Streak/Views/StreakBadgeView.swift
+++ b/college-ios-app/college-ios-app/Features/Streak/Views/StreakBadgeView.swift
@@ -14,8 +14,10 @@ struct StreakBadgeView: View {
     @State private var displayedCount: Int
     @State private var showPlusOne: Bool = false
     @State private var textPopScale: CGFloat = 1.0
+    @State private var containerWidth: CGFloat = 75
     
-    private let containerWidth: CGFloat = 75
+    private let baseWidth: CGFloat = 75
+    private let expandedWidth: CGFloat = 100
     
     init(count: Int, increase: Int = 1, isLoading: Bool = false) {
         self.count = count
@@ -75,19 +77,54 @@ struct StreakBadgeView: View {
     }
     
     private func animateSequence(newValue: Int) {
-        showPlusOne = true
-        textPopScale = 1.1
-        
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { textPopScale = 1.0 }
-        
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) {
-            showPlusOne = false
+        expandWidth {
+            showPlusOne = true
+            textPopScale = 1.1
             
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
-                displayedCount = newValue
-                textPopScale = 1.2
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { textPopScale = 1.0 }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { textPopScale = 1.0 }
+            
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) {
+                showPlusOne = false
+                
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+                    displayedCount = newValue
+                    textPopScale = 1.2
+                    
+                    shrinkWidth {
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { textPopScale = 1.0 }
+                    }
+                }
             }
+        }
+    }
+    
+    private func expandWidth(completion: @escaping () -> Void) {
+        let steps = Int(expandedWidth - baseWidth)
+        let interval: TimeInterval = 0.01
+        
+        for i in 0..<steps {
+            DispatchQueue.main.asyncAfter(deadline: .now() + interval * Double(i)) {
+                containerWidth = baseWidth + CGFloat(i + 1)
+            }
+        }
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + interval * Double(steps)) {
+            completion()
+        }
+    }
+    
+    private func shrinkWidth(completion: @escaping () -> Void) {
+        let steps = Int(expandedWidth - baseWidth)
+        let interval: TimeInterval = 0.01
+        
+        for i in 0..<steps {
+            DispatchQueue.main.asyncAfter(deadline: .now() + interval * Double(i)) {
+                containerWidth = expandedWidth - CGFloat(i + 1)
+            }
+        }
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + interval * Double(steps)) {
+            completion()
         }
     }
 }
@@ -102,7 +139,6 @@ struct StreakBadgeView: View {
         HStack(spacing: 20) {
             VStack {
                 StreakBadgeView(count: 0)
-                    .background(Capsule().fill(Color.gray.opacity(0.1)))
                 Text("Пустой")
                     .font(.caption)
                     .foregroundStyle(.secondary)
@@ -110,7 +146,6 @@ struct StreakBadgeView: View {
             
             VStack {
                 StreakBadgeView(count: 15)
-                    .background(Capsule().fill(Color.gray.opacity(0.1)))
                 Text("Активный")
                     .font(.caption)
                     .foregroundStyle(.secondary)
@@ -118,7 +153,6 @@ struct StreakBadgeView: View {
             
             VStack {
                 StreakBadgeView(count: 0, isLoading: true)
-                    .background(Capsule().fill(Color.gray.opacity(0.1)))
                 Text("Загрузка")
                     .font(.caption)
                     .foregroundStyle(.secondary)
@@ -133,7 +167,6 @@ struct StreakBadgeView: View {
         HStack(spacing: 20) {
             VStack {
                 StreakBadgeView(count: 5, increase: 1)
-                    .background(Capsule().fill(Color.gray.opacity(0.1)))
                 Text("+1 день")
                     .font(.caption)
                     .foregroundStyle(.secondary)
@@ -141,7 +174,6 @@ struct StreakBadgeView: View {
             
             VStack {
                 StreakBadgeView(count: 10, increase: 5)
-                    .background(Capsule().fill(Color.gray.opacity(0.1)))
                 Text("+5 дней")
                     .font(.caption)
                     .foregroundStyle(.secondary)
@@ -149,7 +181,6 @@ struct StreakBadgeView: View {
             
             VStack {
                 StreakBadgeView(count: 15, increase: 15)
-                    .background(Capsule().fill(Color.gray.opacity(0.1)))
                 Text("Первый запуск")
                     .font(.caption)
                     .foregroundStyle(.secondary)
@@ -197,8 +228,12 @@ struct StreakAnimationPreview: View {
             }
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {
-                    StreakBadgeView(count: count, increase: selectedIncrease)
-                        .background(Capsule().fill(Color.gray.opacity(0.1)))
+                    HStack(spacing: 12) {
+                        Image(systemName: "heart.fill")
+                            .foregroundColor(.red)
+                        
+                        StreakBadgeView(count: count, increase: selectedIncrease)
+                    }
                 }
                 
                 ToolbarItem(placement: .principal) {
@@ -249,11 +284,15 @@ struct StreakFirstLaunchPreview: View {
             }
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {
-                    StreakBadgeView(
-                        count: count,
-                        increase: hasLoaded ? 15 : 0
-                    )
-                    .background(Capsule().fill(Color.gray.opacity(0.1)))
+                    HStack(spacing: 12) {
+                        Image(systemName: "heart.fill")
+                            .foregroundColor(.red)
+                        
+                        StreakBadgeView(
+                            count: count,
+                            increase: hasLoaded ? 15 : 0
+                        )
+                    }
                 }
                 
                 ToolbarItem(placement: .principal) {
@@ -304,11 +343,15 @@ struct StreakWeekMissedPreview: View {
             }
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {
-                    StreakBadgeView(
-                        count: count,
-                        increase: hasUpdated ? 5 : 0
-                    )
-                    .background(Capsule().fill(Color.gray.opacity(0.1)))
+                    HStack(spacing: 12) {
+                        Image(systemName: "heart.fill")
+                            .foregroundColor(.red)
+                        
+                        StreakBadgeView(
+                            count: count,
+                            increase: hasUpdated ? 5 : 0
+                        )
+                    }
                 }
                 
                 ToolbarItem(placement: .principal) {

--- a/college-ios-app/college-ios-app/Features/Streak/Views/StreakDetailSheet.swift
+++ b/college-ios-app/college-ios-app/Features/Streak/Views/StreakDetailSheet.swift
@@ -1,0 +1,257 @@
+//
+//  StreakDetailSheet.swift
+//  college-ios-app
+//
+//  Created by pc on 24.11.2025.
+//
+
+import SwiftUI
+
+struct StreakDetailSheet: View {
+    @EnvironmentObject var streakViewModel: StreakViewModel
+    @Environment(\.dismiss) private var dismiss
+    
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(spacing: 24) {
+                    headerSection
+                    
+                    if let streak = streakViewModel.streak {
+                        statisticsSection(streak: streak)
+                        periodSection(streak: streak)
+                    } else if streakViewModel.isLoading {
+                        loadingView
+                    } else if let error = streakViewModel.errorMessage {
+                        errorView(message: error)
+                    }
+                }
+                .padding()
+            }
+            .background(Color(.systemGroupedBackground))
+            .navigationTitle("Посещаемость")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Готово") {
+                        dismiss()
+                    }
+                }
+            }
+        }
+        .presentationDragIndicator(.visible)
+    }
+    
+    private var headerSection: some View {
+        VStack(spacing: 12) {
+            ZStack {
+                Circle()
+                    .fill(
+                        LinearGradient(
+                            colors: [.orange.opacity(0.2), .red.opacity(0.1)],
+                            startPoint: .topLeading,
+                            endPoint: .bottomTrailing
+                        )
+                    )
+                    .frame(width: 100, height: 100)
+                
+                Image(systemName: "flame.fill")
+                    .font(.system(size: 50))
+                    .foregroundStyle(
+                        LinearGradient(
+                            colors: (streakViewModel.streak?.currentStreak ?? 0) > 0
+                            ? [.orange, .red]
+                            : [.gray, .gray.opacity(0.7)],
+                            startPoint: .top,
+                            endPoint: .bottom
+                        )
+                    )
+            }
+            
+            VStack(spacing: 4) {
+                Text("\(streakViewModel.streak?.currentStreak ?? 0)")
+                    .font(.system(size: 48, weight: .bold, design: .rounded))
+                    .foregroundColor(.primary)
+                
+                Text(daysText(streakViewModel.streak?.currentStreak ?? 0))
+                    .font(.title3)
+                    .foregroundColor(.secondary)
+            }
+        }
+        .padding(.vertical)
+    }
+    
+    private func statisticsSection(streak: StreakResponse) -> some View {
+        VStack(spacing: 12) {
+            HStack(spacing: 12) {
+                StatCard(
+                    title: "Рекорд",
+                    value: "\(streak.longestStreak)",
+                    icon: "trophy.fill",
+                    color: .yellow
+                )
+                
+                StatCard(
+                    title: "Посещено",
+                    value: "\(streak.totalDaysAttended)/\(streak.totalSchoolDays)",
+                    icon: "checkmark.circle.fill",
+                    color: .green
+                )
+            }
+            
+            HStack(spacing: 12) {
+                StatCard(
+                    title: "Процент",
+                    value: String(format: "%.0f%%", streak.attendanceRate * 100),
+                    icon: "chart.pie.fill",
+                    color: .blue
+                )
+                
+                if let lastDate = streak.lastAttendedDate, !lastDate.isEmpty {
+                    StatCard(
+                        title: "Последний визит",
+                        value: formatDate(lastDate),
+                        icon: "calendar",
+                        color: .purple
+                    )
+                }
+            }
+        }
+    }
+    
+    private func periodSection(streak: StreakResponse) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Период")
+                .font(.headline)
+                .foregroundColor(.secondary)
+            
+            HStack {
+                Image(systemName: "calendar.badge.clock")
+                    .foregroundColor(.accentColor)
+                
+                Text("\(formatDate(streak.periodStart)) - \(formatDate(streak.periodEnd))")
+                    .font(.subheadline)
+            }
+            .padding()
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(Color(.secondarySystemGroupedBackground))
+            .cornerRadius(12)
+        }
+    }
+    
+    private var loadingView: some View {
+        VStack(spacing: 16) {
+            ProgressView()
+                .scaleEffect(1.2)
+            Text("Загрузка...")
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+        }
+        .padding(.vertical, 40)
+    }
+    
+    private func errorView(message: String) -> some View {
+        VStack(spacing: 16) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: 40))
+                .foregroundColor(.orange)
+            
+            Text(message)
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+            
+            Button {
+                Task {
+                    await streakViewModel.refresh()
+                }
+            } label: {
+                Label("Повторить", systemImage: "arrow.clockwise")
+            }
+            .buttonStyle(.bordered)
+        }
+        .padding(.vertical, 40)
+    }
+    
+    private func daysText(_ count: Int) -> String {
+        let lastDigit = count % 10
+        let lastTwoDigits = count % 100
+        
+        if lastTwoDigits >= 11 && lastTwoDigits <= 19 {
+            return "дней подряд"
+        }
+        
+        switch lastDigit {
+        case 1:
+            return "день подряд"
+        case 2, 3, 4:
+            return "дня подряд"
+        default:
+            return "дней подряд"
+        }
+    }
+    
+    private func formatDate(_ dateString: String) -> String {
+        let inputFormatter = DateFormatter()
+        inputFormatter.dateFormat = "yyyy-MM-dd"
+        
+        guard let date = inputFormatter.date(from: dateString) else {
+            return dateString
+        }
+        
+        let outputFormatter = DateFormatter()
+        outputFormatter.locale = Locale(identifier: "ru_RU")
+        outputFormatter.dateFormat = "d MMM"
+        
+        return outputFormatter.string(from: date)
+    }
+}
+
+private struct StatCard: View {
+    let title: String
+    let value: String
+    let icon: String
+    let color: Color
+    
+    var body: some View {
+        VStack(spacing: 8) {
+            HStack(spacing: 6) {
+                Image(systemName: icon)
+                    .font(.system(size: 14))
+                    .foregroundColor(color)
+                
+                Text(title)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+            
+            Text(value)
+                .font(.system(size: 20, weight: .semibold, design: .rounded))
+                .foregroundColor(.primary)
+        }
+        .frame(maxWidth: .infinity)
+        .padding()
+        .background(Color(.secondarySystemGroupedBackground))
+        .cornerRadius(12)
+    }
+}
+
+#Preview {
+    StreakDetailSheet()
+        .environmentObject(StreakViewModel(api: PreviewStreakAPI()))
+}
+
+private class PreviewStreakAPI: StreakAPIProtocol {
+    func fetchStreak() async throws -> StreakResponse {
+        StreakResponse(
+            currentStreak: 5,
+            longestStreak: 12,
+            totalDaysAttended: 45,
+            totalSchoolDays: 52,
+            attendanceRate: 0.865,
+            lastAttendedDate: "2025-11-25",
+            periodStart: "2025-09-01",
+            periodEnd: "2025-11-25"
+        )
+    }
+}

--- a/college-ios-app/college-ios-app/Features/Streak/Views/StreakDetailSheet.swift
+++ b/college-ios-app/college-ios-app/Features/Streak/Views/StreakDetailSheet.swift
@@ -76,6 +76,10 @@ struct StreakDetailSheet: View {
                 Text(daysText(streakViewModel.streak?.currentStreak ?? 0))
                     .font(.title3)
                     .foregroundColor(.secondary)
+                
+                let titleInfo = titleInfoForStreak(streakViewModel.streak?.currentStreak ?? 0)
+                TitleBadgeView(info: titleInfo)
+                    .padding(.top, 4)
             }
         }
         .padding(.vertical)
@@ -178,6 +182,31 @@ struct StreakDetailSheet: View {
         .padding(.vertical, 40)
     }
     
+    private func titleInfoForStreak(_ count: Int) -> StreakTitleInfo {
+        switch count {
+        case 0:
+            return StreakTitleInfo(title: "Прогульщик", color: .gray)
+        case 1...2:
+            return StreakTitleInfo(title: "Новичок КЦТ", color: .green)
+        case 3...6:
+            return StreakTitleInfo(title: "Студент КЦТ", color: .blue)
+        case 7...13:
+            return StreakTitleInfo(title: "Ветеран КЦТ", color: .purple)
+        case 14...20:
+            return StreakTitleInfo(title: "Мастер КЦТ", color: .pink)
+        case 21...29:
+            return StreakTitleInfo(title: "Элита КЦТ", color: .orange)
+        case 30...49:
+            return StreakTitleInfo(title: "Легенда КЦТ", color: Color(red: 0.95, green: 0.85, blue: 0.45))
+        case 50...74:
+            return StreakTitleInfo(title: "Король КЦТ", color: .orange)
+        case 75...99:
+            return StreakTitleInfo(title: "Император КЦТ", color: Color(red: 0.75, green: 0.82, blue: 0.92))
+        default:
+            return StreakTitleInfo(title: "Бог посещаемости", color: .yellow)
+        }
+    }
+    
     private func daysText(_ count: Int) -> String {
         let lastDigit = count % 10
         let lastTwoDigits = count % 100
@@ -241,6 +270,55 @@ private struct StatCard: View {
     }
 }
 
+// MARK: - Title Badge
+
+private struct StreakTitleInfo {
+    let title: String
+    let color: Color
+}
+
+private struct TitleBadgeView: View {
+    let info: StreakTitleInfo
+    
+    private var secondaryColor: Color {
+        switch info.color {
+        case .yellow: return .orange
+        case .orange: return .yellow
+        default: return .white 
+        }
+    }
+    
+    var body: some View {
+        Text(info.title)
+            .font(.subheadline.weight(.semibold))
+            .foregroundColor(info.color)
+            .padding(.horizontal, 16)
+            .padding(.vertical, 8)
+            .background(
+                LinearGradient(
+                    colors: [
+                        info.color.opacity(0.2),
+                        secondaryColor.opacity(0.15)
+                    ],
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
+                )
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 20)
+                    .stroke(
+                        LinearGradient(
+                            colors: [info.color, secondaryColor],
+                            startPoint: .topLeading,
+                            endPoint: .bottomTrailing
+                        ),
+                        lineWidth: 1.5
+                    )
+            )
+            .cornerRadius(20)
+    }
+}
+
 // MARK: - Previews
 
 #Preview("Активный streak") {
@@ -275,12 +353,60 @@ private struct StatCard: View {
         .task { await vm.loadStreak() }
 }
 
-#Preview("Рекордный streak") {
+#Preview("Легенда КЦТ (30 дней)") {
     let vm = StreakViewModel(api: PreviewStreakAPI(streak: StreakResponse(
-        currentStreak: 31,
-        longestStreak: 31,
+        currentStreak: 30,
+        longestStreak: 30,
         totalDaysAttended: 52,
         totalSchoolDays: 52,
+        attendanceRate: 1.0,
+        lastAttendedDate: "2025-11-25",
+        periodStart: "2025-09-01",
+        periodEnd: "2025-11-25"
+    )))
+    return StreakDetailSheet()
+        .environmentObject(vm)
+        .task { await vm.loadStreak() }
+}
+
+#Preview("Король КЦТ (50-74 дня)") {
+    let vm = StreakViewModel(api: PreviewStreakAPI(streak: StreakResponse(
+        currentStreak: 60,
+        longestStreak: 60,
+        totalDaysAttended: 60,
+        totalSchoolDays: 60,
+        attendanceRate: 1.0,
+        lastAttendedDate: "2025-11-25",
+        periodStart: "2025-09-01",
+        periodEnd: "2025-11-25"
+    )))
+    return StreakDetailSheet()
+        .environmentObject(vm)
+        .task { await vm.loadStreak() }
+}
+
+#Preview("Император КЦТ (75-99 дней)") {
+    let vm = StreakViewModel(api: PreviewStreakAPI(streak: StreakResponse(
+        currentStreak: 85,
+        longestStreak: 85,
+        totalDaysAttended: 85,
+        totalSchoolDays: 85,
+        attendanceRate: 1.0,
+        lastAttendedDate: "2025-11-25",
+        periodStart: "2025-09-01",
+        periodEnd: "2025-11-25"
+    )))
+    return StreakDetailSheet()
+        .environmentObject(vm)
+        .task { await vm.loadStreak() }
+}
+
+#Preview("Бог посещаемости (100+ дней)") {
+    let vm = StreakViewModel(api: PreviewStreakAPI(streak: StreakResponse(
+        currentStreak: 120,
+        longestStreak: 120,
+        totalDaysAttended: 120,
+        totalSchoolDays: 120,
         attendanceRate: 1.0,
         lastAttendedDate: "2025-11-25",
         periodStart: "2025-09-01",
@@ -343,7 +469,7 @@ private class PreviewStreakAPI: StreakAPIProtocol {
     let streak: StreakResponse?
     let shouldFail: Bool
     let delay: TimeInterval
-
+    
     init(
         streak: StreakResponse? = nil,
         shouldFail: Bool = false,
@@ -353,7 +479,7 @@ private class PreviewStreakAPI: StreakAPIProtocol {
         self.shouldFail = shouldFail
         self.delay = delay
     }
-
+    
     func fetchStreak() async throws -> StreakResponse {
         if delay > 0 {
             try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))

--- a/college-ios-app/college-ios-app/Features/Streak/Views/StreakDetailSheet.swift
+++ b/college-ios-app/college-ios-app/Features/Streak/Views/StreakDetailSheet.swift
@@ -167,8 +167,13 @@ struct StreakDetailSheet: View {
                 }
             } label: {
                 Label("Повторить", systemImage: "arrow.clockwise")
+                    .font(.subheadline.weight(.medium))
+                    .padding(.horizontal, 24)
+                    .padding(.vertical, 12)
+                    .background(Color.blue)
+                    .foregroundColor(.white)
+                    .cornerRadius(25)
             }
-            .buttonStyle(.bordered)
         }
         .padding(.vertical, 40)
     }
@@ -236,14 +241,127 @@ private struct StatCard: View {
     }
 }
 
-#Preview {
-    StreakDetailSheet()
-        .environmentObject(StreakViewModel(api: PreviewStreakAPI()))
+// MARK: - Previews
+
+#Preview("Активный streak") {
+    let vm = StreakViewModel(api: PreviewStreakAPI(streak: StreakResponse(
+        currentStreak: 5,
+        longestStreak: 12,
+        totalDaysAttended: 45,
+        totalSchoolDays: 52,
+        attendanceRate: 0.865,
+        lastAttendedDate: "2025-11-25",
+        periodStart: "2025-09-01",
+        periodEnd: "2025-11-25"
+    )))
+    return StreakDetailSheet()
+        .environmentObject(vm)
+        .task { await vm.loadStreak() }
 }
 
+#Preview("Нулевой streak") {
+    let vm = StreakViewModel(api: PreviewStreakAPI(streak: StreakResponse(
+        currentStreak: 0,
+        longestStreak: 7,
+        totalDaysAttended: 30,
+        totalSchoolDays: 52,
+        attendanceRate: 0.577,
+        lastAttendedDate: "2025-11-20",
+        periodStart: "2025-09-01",
+        periodEnd: "2025-11-25"
+    )))
+    return StreakDetailSheet()
+        .environmentObject(vm)
+        .task { await vm.loadStreak() }
+}
+
+#Preview("Рекордный streak") {
+    let vm = StreakViewModel(api: PreviewStreakAPI(streak: StreakResponse(
+        currentStreak: 31,
+        longestStreak: 31,
+        totalDaysAttended: 52,
+        totalSchoolDays: 52,
+        attendanceRate: 1.0,
+        lastAttendedDate: "2025-11-25",
+        periodStart: "2025-09-01",
+        periodEnd: "2025-11-25"
+    )))
+    return StreakDetailSheet()
+        .environmentObject(vm)
+        .task { await vm.loadStreak() }
+}
+
+#Preview("Один день") {
+    let vm = StreakViewModel(api: PreviewStreakAPI(streak: StreakResponse(
+        currentStreak: 1,
+        longestStreak: 1,
+        totalDaysAttended: 1,
+        totalSchoolDays: 1,
+        attendanceRate: 1.0,
+        lastAttendedDate: "2025-11-25",
+        periodStart: "2025-11-25",
+        periodEnd: "2025-11-25"
+    )))
+    return StreakDetailSheet()
+        .environmentObject(vm)
+        .task { await vm.loadStreak() }
+}
+
+#Preview("Без последнего визита") {
+    let vm = StreakViewModel(api: PreviewStreakAPI(streak: StreakResponse(
+        currentStreak: 3,
+        longestStreak: 10,
+        totalDaysAttended: 40,
+        totalSchoolDays: 50,
+        attendanceRate: 0.8,
+        lastAttendedDate: nil,
+        periodStart: "2025-09-01",
+        periodEnd: "2025-11-25"
+    )))
+    return StreakDetailSheet()
+        .environmentObject(vm)
+        .task { await vm.loadStreak() }
+}
+
+#Preview("Загрузка") {
+    let vm = StreakViewModel(api: PreviewStreakAPI(delay: 999))
+    return StreakDetailSheet()
+        .environmentObject(vm)
+        .task { await vm.loadStreak() }
+}
+
+#Preview("Ошибка") {
+    let vm = StreakViewModel(api: PreviewStreakAPI(shouldFail: true))
+    return StreakDetailSheet()
+        .environmentObject(vm)
+        .task { await vm.loadStreak() }
+}
+
+// MARK: - Preview Helpers
+
 private class PreviewStreakAPI: StreakAPIProtocol {
+    let streak: StreakResponse?
+    let shouldFail: Bool
+    let delay: TimeInterval
+
+    init(
+        streak: StreakResponse? = nil,
+        shouldFail: Bool = false,
+        delay: TimeInterval = 0
+    ) {
+        self.streak = streak
+        self.shouldFail = shouldFail
+        self.delay = delay
+    }
+
     func fetchStreak() async throws -> StreakResponse {
-        StreakResponse(
+        if delay > 0 {
+            try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+        }
+        if shouldFail {
+            throw APIError.decodingFailed
+        }
+        return streak ?? StreakResponse(
             currentStreak: 5,
             longestStreak: 12,
             totalDaysAttended: 45,

--- a/college-ios-app/college-ios-app/Utils/StreakToolbarModifier.swift
+++ b/college-ios-app/college-ios-app/Utils/StreakToolbarModifier.swift
@@ -20,6 +20,7 @@ struct StreakToolbarModifier: ViewModifier {
                         } label: {
                             StreakBadgeView(
                                 count: streakViewModel.streak?.currentStreak ?? 0,
+                                increase: streakViewModel.streakIncrease,
                                 isLoading: streakViewModel.isLoading
                             )
                         }

--- a/college-ios-app/college-ios-app/Utils/StreakToolbarModifier.swift
+++ b/college-ios-app/college-ios-app/Utils/StreakToolbarModifier.swift
@@ -1,0 +1,42 @@
+//
+//  StreakToolbarModifier.swift
+//  college-ios-app
+//
+
+import SwiftUI
+
+struct StreakToolbarModifier: ViewModifier {
+    @EnvironmentObject var sessionViewModel: SessionViewModel
+    @EnvironmentObject var streakViewModel: StreakViewModel
+    @State private var showStreakSheet = false
+
+    func body(content: Content) -> some View {
+        content
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    if sessionViewModel.isAuthenticated {
+                        Button {
+                            showStreakSheet = true
+                        } label: {
+                            StreakBadgeView(
+                                count: streakViewModel.streak?.currentStreak ?? 0,
+                                isLoading: streakViewModel.isLoading
+                            )
+                        }
+                    }
+                }
+            }
+            .sheet(isPresented: $showStreakSheet) {
+                StreakDetailSheet()
+                    .environmentObject(streakViewModel)
+            }
+    }
+}
+
+// MARK: - View Extension
+
+extension View {
+    func streakToolbar() -> some View {
+        self.modifier(StreakToolbarModifier())
+    }
+}


### PR DESCRIPTION
## Summary

  - Add new Streak feature module with badge visualization and detail sheet
  - Implement streak tracking and persistence with `StreakStorage` and
  `StreakAPI`
  - Integrate streak toolbar modifier across Attendance, Performance, and
  Schedule views
  - Add clear/reset logic for attendance, performance, and streak data in
  Developer Settings

  ## Changes

  ### New Files
  - `StreakAPI.swift` - API layer for streak data
  - `StreakStorage.swift` - Local persistence for streak state
  - `StreakResponse.swift` - Model for streak data
  - `StreakViewModel.swift` - Business logic for streak feature
  - `StreakBadgeView.swift` - Visual badge component with title badges
  - `StreakDetailSheet.swift` - Detailed streak information sheet
  - `StreakToolbarModifier.swift` - Reusable toolbar integration

  ### Modified Files
  - Updated `AttendanceViewModel` and `PerformanceViewModel` with streak
  increase tracking
  - Enhanced `DeveloperSettingsView` with reset options
  - Integrated streak toolbar into main app views